### PR TITLE
BTFS-1525 use go-btfs repo releases for binary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This project provides all the binaries supported by btfs. See the attached opera
 
 | OS      | ARCH  | Download                                                     |
 | ------- | ----- | ------------------------------------------------------------ |
-| darwin  | amd64 | [darwin-amd64](https://raw.githubusercontent.com/TRON-US/btfs-binary-releases/master/darwin/amd64/btfs-darwin-amd64.tar) |
-| darwin  | 386   | [darwin-386](https://raw.githubusercontent.com/TRON-US/btfs-binary-releases/master/darwin/386/btfs-darwin-386.tar) |
-| linux   | amd64 | [linux-amd64](https://raw.githubusercontent.com/TRON-US/btfs-binary-releases/master/linux/amd64/btfs-linux-amd64.tar) |
-| linux   | 386   | [linux-386](https://raw.githubusercontent.com/TRON-US/btfs-binary-releases/master/linux/386/btfs-linux-386.tar) |
-| windows | amd64 | [windows-amd64](https://raw.githubusercontent.com/TRON-US/btfs-binary-releases/master/windows/amd64/btfs-windows-amd64.zip) |
-| windows | 386   | [window-386](https://raw.githubusercontent.com/TRON-US/btfs-binary-releases/master/windows/386/btfs-windows-386.zip) |
+| darwin  | amd64 | [darwin-amd64](https://github.com/TRON-US/go-btfs/releases/latest/download/btfs-darwin-amd64.tar) |
+| darwin  | 386   | [darwin-386](https://github.com/TRON-US/go-btfs/releases/latest/download/btfs-darwin-386.tar) |
+| linux   | amd64 | [linux-amd64](https://github.com/TRON-US/go-btfs/releases/latest/download/btfs-linux-amd64.tar) |
+| linux   | 386   | [linux-386](https://github.com/TRON-US/go-btfs/releases/latest/download/btfs-linux-386.tar) |
+| windows | amd64 | [windows-amd64](https://github.com/TRON-US/go-btfs/releases/latest/download/btfs-windows-amd64.zip) |
+| windows | 386   | [window-386](https://github.com/TRON-US/go-btfs/releases/latest/download/btfs-windows-386.zip) |
 
 
 
@@ -50,7 +50,7 @@ btfs daemon
 
 
 
-Now btfs on mac or linux is already installed.
+Now btfs on mac or linux is installed.
 
 
 

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ fi
 
 cd ${HOME}
 
-wget https://raw.githubusercontent.com/TRON-US/btfs-binary-releases/master/${OS}/${ARCH}/btfs-${OS}-${ARCH}.tar
+wget https://github.com/TRON-US/go-btfs/releases/latest/download/btfs-${OS}-${ARCH}.tar
 tar -xvf btfs-${OS}-${ARCH}.tar
 rm btfs-${OS}-${ARCH}.tar
 


### PR DESCRIPTION
update README and install script to download binary file from go-btfs repo to transition away from maintaining a separate btfs-binarary-releases repo.